### PR TITLE
export interfaces inline

### DIFF
--- a/s2ts.go
+++ b/s2ts.go
@@ -170,7 +170,7 @@ func (s *StructToTS) RenderTo(w io.Writer) (err error) {
 		io.WriteString(w, "\n")
 	}
 
-	io.WriteString(w, "// classes\n")
+	io.WriteString(w, "// structs\n")
 	for _, st := range s.structs {
 		if err = st.RenderTo(s.opts, buf); err != nil {
 			return
@@ -186,6 +186,11 @@ func (s *StructToTS) RenderTo(w io.Writer) (err error) {
 }
 
 func (s *StructToTS) RenderExports(w io.Writer) (err error) {
+	if s.opts.InterfaceOnly && s.opts.NoHelpers {
+		// nothing else to export
+		return nil
+	}
+
 	io.WriteString(w, "// exports\n")
 
 	export := func(n string) { _, err = fmt.Fprintf(w, "%s%s,\n", s.opts.indents[1], n) }
@@ -196,8 +201,11 @@ func (s *StructToTS) RenderExports(w io.Writer) (err error) {
 		io.WriteString(w, "export {\n")
 	}
 
-	for _, st := range s.structs {
-		export(st.Name)
+	// interfaces are exported inline!
+	if !s.opts.InterfaceOnly {
+		for _, st := range s.structs {
+			export(st.Name)
+		}
 	}
 
 	if !s.opts.NoHelpers {

--- a/struct.go
+++ b/struct.go
@@ -31,6 +31,9 @@ func (s *Struct) RenderTo(opts *Options, w io.Writer) (err error) {
 		if opts.ES6 { // no interfaces in js
 			return
 		}
+		if !opts.NoExports {
+			fmt.Fprintf(w, "export ")
+		}
 		_, err = fmt.Fprintf(w, "interface %s {\n", s.Name)
 	} else {
 		_, err = fmt.Fprintf(w, "class %s {\n", s.Name)


### PR DESCRIPTION
The typescript compiler doesn't like when interfaces are exported in an 'export {...}' block, specially when the module has nothing but interfaces.